### PR TITLE
multiple mail recipients

### DIFF
--- a/Subscriber/Backend/QueryManagerCron.php
+++ b/Subscriber/Backend/QueryManagerCron.php
@@ -114,7 +114,7 @@ class QueryManagerCron implements SubscriberInterface
                         if(!empty($mailRecipient)){
                             $mail = clone $this->container->get('mail');
                             $mail->setFrom($this->container->get('config')->get('mail'));
-                            $mail->addTo($mailRecipient);
+                            $mail->addTo(array_map('trim', explode(",", $mailRecipient)));
                             $mail->setSubject($cronJob['name']);
                             $mail->setBodyText($rowCount . ' ' . $snippets->get('rowsAffected', 'Reihen betroffen'));
                             $mail->createAttachment(


### PR DESCRIPTION
This small change adds support for multiple mail recipients, by separating mail addresses with comma